### PR TITLE
irssi: do not force nickname if not necesary

### DIFF
--- a/irssi/scripts/keyring.pl
+++ b/irssi/scripts/keyring.pl
@@ -36,13 +36,13 @@ Irssi::command_bind keyring => sub {
       next;
     }
 
-    if(!$username || ($account && $account ne $username)){
-      next;
-    }
-
     # handle alternate username
     if($command =~ m/.*<password:([^>]*)>.*/){
       $username = $1;
+    }
+
+    if(!$username || ($account && $account ne $username)){
+      next;
     }
 
     my ($stdin, $stdout, $stderr);


### PR DESCRIPTION
Currently, it is mandatory to specify a nickname, and this value
overrides settings that were set in config file (settings/core/nick).

This commit allows not to set a nickname if it is not necessary. ie.
it allows the following syntax:
  connect irc.example.com 6667 password:user@server

By moving the check on "username", we give a chance to the script to
extract its value from the password:key string. This way, the call to
"keyring password" can be achieved and nickname is not overriden.
