### PR TITLE
handle gracefully ill-formed keys

### DIFF
--- a/bin/keyring
+++ b/bin/keyring
@@ -275,7 +275,10 @@ def main():
           name = '%s -> %s' % (key, items[0].attributes['link'])
       except gnomekeyring.NoMatchError:
         # handle smtp keys
-        user, server = key.rsplit('@', 1)
+        try:
+            user, server = key.rsplit('@', 1)
+        except ValueError:
+            continue
         attrs = {'user': user, 'server': server, 'protocol': 'smtp'}
         items = gnomekeyring.find_items_sync(
           gnomekeyring.ITEM_NETWORK_PASSWORD, attrs


### PR DESCRIPTION
If a key in the keyring is not in the user@server format, "list" command
will trigger an exception. For instance, the network manager adds keys
that look like "Network secret for XXX". Just skip these keys.

It's pretty annoying when used with the bash completion script since
every strike on <TAB> triggers the exception.
